### PR TITLE
Fix published config source path

### DIFF
--- a/src/Provider/DbMaintenanceProvider.php
+++ b/src/Provider/DbMaintenanceProvider.php
@@ -68,7 +68,7 @@ class DbMaintenanceProvider extends ServiceProvider
     protected function publishesConfiguration()
     {
         $this->publishes([
-            __DIR__ . '/../../db_maintenance.php' => config_path('db_maintenance.php'),
+            __DIR__ . '/../../config/db_maintenance.php' => config_path('db_maintenance.php'),
         ], 'config');
     }
 }


### PR DESCRIPTION
Publishing config will currently fail as the source path is incorrect. doh!

### Test

`php artisan vendor:publish --provider="FriendsOfCat\LaravelDbMaintenance\Provider\DbMaintenanceProvider" --tag="config"`