### PR TITLE
Laravel 10 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "type": "library",
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^9.0"
+        "laravel/framework": "^9.0|^10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "orchestra/testbench": "^5.0|^6.0|^7.0",
+        "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0",
         "mockery/mockery": "^1.1",
         "squizlabs/php_codesniffer": "^3.3",
         "php-coveralls/php-coveralls": "^2.1",

--- a/src/Http/Middleware/CheckDbMaintenance.php
+++ b/src/Http/Middleware/CheckDbMaintenance.php
@@ -3,8 +3,8 @@
 namespace FriendsOfCat\LaravelDbMaintenance\Http\Middleware;
 
 use FriendsOfCat\LaravelDbMaintenance\Maintenance;
-use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 class CheckDbMaintenance
 {
@@ -35,7 +35,7 @@ class CheckDbMaintenance
     {
         if ($this->maintenance->isDown()) {
             $latest = $this->maintenance->getLatest();
-            throw new MaintenanceModeException($latest->created_at, $latest->retry_after, $latest->message);
+            throw new ServiceUnavailableHttpException($latest->retry_after, $latest->message);
         }
 
         return $next($request);

--- a/src/Maintenance.php
+++ b/src/Maintenance.php
@@ -9,9 +9,9 @@ use Illuminate\Support\Facades\DB;
 class Maintenance
 {
 
-  /**
-   * @var string
-   */
+    /**
+     * @var string
+     */
     protected $tableName = 'maintenance';
 
     /**
@@ -55,11 +55,11 @@ class Maintenance
         $max = $this->getTableBuilder()->max('id');
 
         return (bool) $this->getTableBuilder()
-      ->where('id', $max)
-      ->update([
-        'status' => false,
-        'updated_at' => $this->nowTimestamp(),
-      ]);
+            ->where('id', $max)
+            ->update([
+                'status' => false,
+                'updated_at' => $this->nowTimestamp(),
+            ]);
     }
 
     /**
@@ -87,12 +87,12 @@ class Maintenance
         $now = $this->nowTimestamp();
 
         return $this->getTableBuilder()->insert([
-      'created_at' => $now,
-      'updated_at' => $now,
-      'status' => true,
-      'retry_after' => $retry_after,
-      'message' => $message,
-    ]);
+            'created_at' => $now,
+            'updated_at' => $now,
+            'status' => true,
+            'retry_after' => $retry_after,
+            'message' => $message,
+        ]);
     }
 
     /**
@@ -110,9 +110,9 @@ class Maintenance
     {
         if (!isset($this->latest)) {
             $this->latest = $this->getTableBuilder()
-        ->orderBy('id', 'desc')
-        ->limit(1)
-        ->first();
+                ->orderBy('id', 'desc')
+                ->limit(1)
+                ->first();
 
             if (is_null($this->latest)) {
                 $this->latest = $this->defaultLatest();

--- a/tests/src/Http/Middleware/CheckDbMaintenanceTest.php
+++ b/tests/src/Http/Middleware/CheckDbMaintenanceTest.php
@@ -5,10 +5,10 @@ namespace FriendsOfCat\Tests\LaravelDbMaintenance\Http\Middleware;
 use Carbon\Carbon;
 use FriendsOfCat\LaravelDbMaintenance\Http\Middleware\CheckDbMaintenance;
 use FriendsOfCat\LaravelDbMaintenance\Maintenance;
-use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 /**
  * @coversDefaultClass \FriendsOfCat\LaravelDbMaintenance\Http\Middleware\CheckDbMaintenance
@@ -43,7 +43,7 @@ class CheckDbMaintenanceTest extends TestCase
      */
     public function testHandleWhenDown()
     {
-        $this->expectException(MaintenanceModeException::class);
+        $this->expectException(ServiceUnavailableHttpException::class);
 
         Carbon::setTestNow();
 


### PR DESCRIPTION
Add Laravel 10 support.

### Important
Laravel 10 removes the `MaintenanceModeException`, a small refactoring was done using the `ServiceUnavailableHttpException` class which was the parent of the previous exception. Behavior is the same.

`composer test` run logs:

```
➜  laravel-db-maintenance git:(GM-117) composer test
> phpunit
PHPUnit 9.6.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.6
Configuration: /Users/deimarherrera/dev/laravel-db-maintenance/phpunit.xml
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

........                                                            8 / 8 (100%)

Time: 00:00.169, Memory: 28.00 MB

OK (8 tests, 65 assertions)
```